### PR TITLE
Fixed DateCombo to be consistent for a <=> b and b <=> a.

### DIFF
--- a/lib/pair_see.rb
+++ b/lib/pair_see.rb
@@ -172,8 +172,10 @@ class PairSee
         date <=> other.date
       elsif date
         1
-      else
+      elsif other.date
         -1
+      else
+        0
       end
     end
   end


### PR DESCRIPTION
Updated <=> function of DateCombo to be consistent for a <=> b and b <=> a when both dates are missing.

I haven't actually tested this change -- just having too much fun coding in the browser...  so accept at your own risk :)
